### PR TITLE
Add correlation id support

### DIFF
--- a/Inlocuiremasina-API/Middleware/V1/Logging/Extension/LoggingExtension.cs
+++ b/Inlocuiremasina-API/Middleware/V1/Logging/Extension/LoggingExtension.cs
@@ -39,7 +39,8 @@ namespace Middleware.V1.Logging.Extension
                     new SqlColumn { ColumnName = "ErrorMessage", DataType = System.Data.SqlDbType.NVarChar, AllowNull = true },
                     new SqlColumn { ColumnName = "StackTrace", DataType = System.Data.SqlDbType.NVarChar, AllowNull = true },
                     new SqlColumn { ColumnName = "FileName", DataType = System.Data.SqlDbType.NVarChar, AllowNull = true },
-                    new SqlColumn { ColumnName = "LineNumber", DataType = System.Data.SqlDbType.Int, AllowNull = true }
+                    new SqlColumn { ColumnName = "LineNumber", DataType = System.Data.SqlDbType.Int, AllowNull = true },
+                    new SqlColumn { ColumnName = "CorrelationId", DataType = System.Data.SqlDbType.NVarChar, AllowNull = false }
                 }
             };
 

--- a/Inlocuiremasina-API/Middleware/V1/Logging/LoggingMiddleware.cs
+++ b/Inlocuiremasina-API/Middleware/V1/Logging/LoggingMiddleware.cs
@@ -74,6 +74,7 @@ namespace Middleware.V1.Logging
             using (LogContext.PushProperty("Route", logData.Route))
             using (LogContext.PushProperty("StatusCode", logData.StatusCode))
             using (LogContext.PushProperty("ResponseTimeMs", logData.ResponseTimeMs))
+            using (LogContext.PushProperty("CorrelationId", requestMetadata.correlationId))
             {
                 Log.Information($"Success: {logData.Method} {logData.Route} responded with {logData.StatusCode} in {logData.ResponseTimeMs}ms");
             }
@@ -100,6 +101,7 @@ namespace Middleware.V1.Logging
             using (LogContext.PushProperty("FileName", fileName))
             using (LogContext.PushProperty("LineNumber", lineNumber))
             using (LogContext.PushProperty("ResponseTimeMs", elapsedMs))
+            using (LogContext.PushProperty("CorrelationId", requestMetadata.correlationId))
             {
                 Log.Error($"Error: {context.Request.Method} {context.Request.Path} responded with {statusCode} in {elapsedMs}ms");
             }

--- a/Inlocuiremasina-API/Middleware/V1/Request/Model/RequestMetadata.cs
+++ b/Inlocuiremasina-API/Middleware/V1/Request/Model/RequestMetadata.cs
@@ -1,8 +1,11 @@
-﻿namespace Middleware.V1.Request.Model
+using System;
+
+namespace Middleware.V1.Request.Model
 {
     public class RequestMetadata
     {
         public string lang { get; set; } = "en";  // Default value
         public int userId { get; set; } = 0; // Default value
+        public string correlationId { get; set; } = Guid.NewGuid().ToString();
     }
 }


### PR DESCRIPTION
## Summary
- generate a correlation id for each request via `RequestMetadataMiddleware`
- push the correlation id into Serilog context for requests and errors
- persist the correlation id in `ApplicationLogs` table via Serilog configuration
- ensure correlation id is available for the entire request lifecycle

## Testing
- `dotnet build Inlocuiremasina-API.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888c2ba78e48321821fe5b7314d36a6